### PR TITLE
refactor: 5가지 코드 스멜 식별 및 리팩토링

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,15 @@ app.config['TESTING'] = False
 init_db(app)
 
 
+def validate_post_form(form):
+    title = form['title']
+    content = form['content']
+    category = form.get('category', 'general')
+    if not title.strip() or not content.strip():
+        return None, None, None, "제목과 내용을 입력해주세요"
+    return title, content, category, None
+
+
 @app.route('/')
 def index():
     category = request.args.get('category')
@@ -38,11 +47,9 @@ def post_detail(post_id):
 @app.route('/create', methods=['GET', 'POST'])
 def create():
     if request.method == 'POST':
-        title = request.form['title']
-        content = request.form['content']
-        category = request.form.get('category', 'general')
-        if not title.strip() or not content.strip():
-            return render_template('form.html', error="제목과 내용을 입력해주세요")
+        title, content, category, error = validate_post_form(request.form)
+        if error:
+            return render_template('form.html', error=error)
         create_post(title, content, category)
         return redirect(url_for('index'))
     return render_template('form.html')
@@ -52,11 +59,9 @@ def create():
 def edit(post_id):
     post = get_post(post_id)
     if request.method == 'POST':
-        title = request.form['title']
-        content = request.form['content']
-        category = request.form.get('category', 'general')
-        if not title.strip() or not content.strip():
-            return render_template('form.html', post=post, error="제목과 내용을 입력해주세요")
+        title, content, category, error = validate_post_form(request.form)
+        if error:
+            return render_template('form.html', post=post, error=error)
         update_post(post_id, title, content, category)
         return redirect(url_for('index'))
     return render_template('form.html', post=post)

--- a/models.py
+++ b/models.py
@@ -41,37 +41,34 @@ def init_db(app):
         db.close()
 
 
+def _build_post_query(category=None):
+    where_clause = ""
+    params = []
+    if category:
+        where_clause = " WHERE category = ?"
+        params.append(category)
+    return where_clause, params
+
+
 def get_all_posts(category=None, page=None, per_page=5):
     db = get_db()
+    where_clause, params = _build_post_query(category)
+
     if page is None:
-        if category:
-            posts = db.execute(
-                "SELECT * FROM posts WHERE category = ? ORDER BY created_at DESC",
-                (category,)
-            ).fetchall()
-        else:
-            posts = db.execute(
-                "SELECT * FROM posts ORDER BY created_at DESC"
-            ).fetchall()
+        posts = db.execute(
+            f"SELECT * FROM posts{where_clause} ORDER BY created_at DESC",
+            params
+        ).fetchall()
         return posts
 
-    if category:
-        total = db.execute(
-            "SELECT COUNT(*) as count FROM posts WHERE category = ?",
-            (category,)
-        ).fetchone()['count']
-        posts = db.execute(
-            "SELECT * FROM posts WHERE category = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            (category, per_page, (page - 1) * per_page)
-        ).fetchall()
-    else:
-        total = db.execute(
-            "SELECT COUNT(*) as count FROM posts"
-        ).fetchone()['count']
-        posts = db.execute(
-            "SELECT * FROM posts ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            (per_page, (page - 1) * per_page)
-        ).fetchall()
+    total = db.execute(
+        f"SELECT COUNT(*) as count FROM posts{where_clause}",
+        params
+    ).fetchone()['count']
+    posts = db.execute(
+        f"SELECT * FROM posts{where_clause} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+        params + [per_page, (page - 1) * per_page]
+    ).fetchall()
 
     total_pages = (total + per_page - 1) // per_page
     return {

--- a/templates/_post_list.html
+++ b/templates/_post_list.html
@@ -1,0 +1,9 @@
+<ul class="post-list">
+    {% for post in posts %}
+    <li>
+        <a href="{{ url_for('post_detail', post_id=post['id']) }}">{{ post['title'] }}</a>
+        <span class="category">{{ post['category'] }}</span>
+        <span class="date">{{ post['created_at'] }}</span>
+    </li>
+    {% endfor %}
+</ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,9 +8,9 @@
 </head>
 <body>
     <nav>
-        <a href="/">홈</a>
-        <a href="/create">글 작성</a>
-        <a href="/stats">통계</a>
+        <a href="{{ url_for('index') }}">홈</a>
+        <a href="{{ url_for('create') }}">글 작성</a>
+        <a href="{{ url_for('stats') }}">통계</a>
     </nav>
     <main>
         {% block content %}{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,15 +13,7 @@
     <a href="{{ url_for('index', category='life') }}">일상</a>
     <a href="{{ url_for('index', category='study') }}">공부</a>
 </div>
-<ul class="post-list">
-    {% for post in posts %}
-    <li>
-        <a href="{{ url_for('post_detail', post_id=post['id']) }}">{{ post['title'] }}</a>
-        <span class="category">{{ post['category'] }}</span>
-        <span class="date">{{ post['created_at'] }}</span>
-    </li>
-    {% endfor %}
-</ul>
+{% include '_post_list.html' %}
 {% if pagination and pagination.total_pages > 1 %}
 <div class="pagination">
     {% for p in range(1, pagination.total_pages + 1) %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,21 +2,21 @@
 {% block title %}글 목록 - Flask Blog{% endblock %}
 {% block content %}
 <h1>글 목록</h1>
-<form action="/search" method="GET" class="search-form">
+<form action="{{ url_for('search') }}" method="GET" class="search-form">
     <input type="text" name="q" placeholder="검색어를 입력하세요">
     <button type="submit">검색</button>
 </form>
 <div class="category-filter">
-    <a href="/">전체</a>
-    <a href="/?category=general">일반</a>
-    <a href="/?category=tech">기술</a>
-    <a href="/?category=life">일상</a>
-    <a href="/?category=study">공부</a>
+    <a href="{{ url_for('index') }}">전체</a>
+    <a href="{{ url_for('index', category='general') }}">일반</a>
+    <a href="{{ url_for('index', category='tech') }}">기술</a>
+    <a href="{{ url_for('index', category='life') }}">일상</a>
+    <a href="{{ url_for('index', category='study') }}">공부</a>
 </div>
 <ul class="post-list">
     {% for post in posts %}
     <li>
-        <a href="/post/{{ post['id'] }}">{{ post['title'] }}</a>
+        <a href="{{ url_for('post_detail', post_id=post['id']) }}">{{ post['title'] }}</a>
         <span class="category">{{ post['category'] }}</span>
         <span class="date">{{ post['created_at'] }}</span>
     </li>
@@ -25,7 +25,7 @@
 {% if pagination and pagination.total_pages > 1 %}
 <div class="pagination">
     {% for p in range(1, pagination.total_pages + 1) %}
-    <a href="/?page={{ p }}{% if category %}&category={{ category }}{% endif %}"
+    <a href="{{ url_for('index', page=p, category=category) if category else url_for('index', page=p) }}"
        {% if p == pagination.page %}class="active"{% endif %}>{{ p }}</a>
     {% endfor %}
 </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -11,11 +11,11 @@
         {{ post['content'] }}
     </div>
     <div class="post-actions">
-        <a href="/edit/{{ post['id'] }}">수정</a>
-        <form method="POST" action="/delete/{{ post['id'] }}" style="display:inline;">
+        <a href="{{ url_for('edit', post_id=post['id']) }}">수정</a>
+        <form method="POST" action="{{ url_for('delete', post_id=post['id']) }}" style="display:inline;">
             <button type="submit">삭제</button>
         </form>
     </div>
 </article>
-<a href="/">목록으로</a>
+<a href="{{ url_for('index') }}">목록으로</a>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -6,7 +6,7 @@
 <ul class="post-list">
     {% for post in posts %}
     <li>
-        <a href="/post/{{ post['id'] }}">{{ post['title'] }}</a>
+        <a href="{{ url_for('post_detail', post_id=post['id']) }}">{{ post['title'] }}</a>
         <span class="category">{{ post['category'] }}</span>
         <span class="date">{{ post['created_at'] }}</span>
     </li>

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,15 +3,7 @@
 {% block content %}
 <h1>"{{ query }}" 검색 결과</h1>
 {% if posts %}
-<ul class="post-list">
-    {% for post in posts %}
-    <li>
-        <a href="{{ url_for('post_detail', post_id=post['id']) }}">{{ post['title'] }}</a>
-        <span class="category">{{ post['category'] }}</span>
-        <span class="date">{{ post['created_at'] }}</span>
-    </li>
-    {% endfor %}
-</ul>
+{% include '_post_list.html' %}
 {% else %}
 <p>검색 결과가 없습니다</p>
 {% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ import tempfile
 import pytest
 
 from app import app
-from models import get_db, get_all_posts
+from models import get_db, get_all_posts, SCHEMA
 
 
 @pytest.fixture
@@ -16,16 +16,7 @@ def client():
 
     with app.app_context():
         db = sqlite3.connect(db_path)
-        db.execute('''
-            CREATE TABLE IF NOT EXISTS posts (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                title TEXT NOT NULL,
-                content TEXT NOT NULL,
-                category TEXT DEFAULT 'general',
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-        ''')
+        db.execute(SCHEMA)
         db.commit()
         db.close()
 
@@ -34,6 +25,15 @@ def client():
 
     os.close(db_fd)
     os.unlink(db_path)
+
+
+def insert_post(title='테스트 글', content='테스트 내용', category='general'):
+    db = get_db()
+    db.execute(
+        "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
+        (title, content, category)
+    )
+    db.commit()
 
 
 class TestIndex:
@@ -47,27 +47,14 @@ class TestIndex:
 
     def test_index_page_shows_posts(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('테스트 글', '테스트 내용', 'tech')
-            )
-            db.commit()
+            insert_post('테스트 글', '테스트 내용', 'tech')
             response = client.get('/')
             assert '테스트 글'.encode() in response.data
 
     def test_index_page_filter_by_category(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('기술 글', '내용', 'tech')
-            )
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('일상 글', '내용', 'life')
-            )
-            db.commit()
+            insert_post('기술 글', '내용', 'tech')
+            insert_post('일상 글', '내용', 'life')
             response = client.get('/?category=tech')
             assert '기술 글'.encode() in response.data
             assert '일상 글'.encode() not in response.data
@@ -89,24 +76,14 @@ class TestCRUD:
 
     def test_edit_page_returns_200(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('수정할 글', '내용', 'general')
-            )
-            db.commit()
+            insert_post('수정할 글', '내용', 'general')
             response = client.get('/edit/1')
             assert response.status_code == 200
             assert '수정할 글'.encode() in response.data
 
     def test_edit_post(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('원본 글', '원본 내용', 'general')
-            )
-            db.commit()
+            insert_post('원본 글', '원본 내용', 'general')
         response = client.post('/edit/1', data={
             'title': '수정된 글',
             'content': '수정된 내용',
@@ -117,12 +94,7 @@ class TestCRUD:
 
     def test_delete_post(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('삭제할 글', '내용', 'general')
-            )
-            db.commit()
+            insert_post('삭제할 글', '내용', 'general')
         response = client.post('/delete/1', follow_redirects=True)
         assert response.status_code == 200
         assert '삭제할 글'.encode() not in response.data
@@ -131,23 +103,13 @@ class TestCRUD:
 class TestDetail:
     def test_post_detail_returns_200(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('상세 글', '상세 내용입니다', 'tech')
-            )
-            db.commit()
+            insert_post('상세 글', '상세 내용입니다', 'tech')
         response = client.get('/post/1')
         assert response.status_code == 200
 
     def test_post_detail_shows_content(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('상세 글', '상세 내용입니다', 'tech')
-            )
-            db.commit()
+            insert_post('상세 글', '상세 내용입니다', 'tech')
         response = client.get('/post/1')
         assert '상세 글'.encode() in response.data
         assert '상세 내용입니다'.encode() in response.data
@@ -164,16 +126,8 @@ class TestStats:
 
     def test_stats_shows_total_count(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('글1', '내용', 'tech')
-            )
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('글2', '내용', 'life')
-            )
-            db.commit()
+            insert_post('글1', '내용', 'tech')
+            insert_post('글2', '내용', 'life')
         response = client.get('/stats')
         assert response.status_code == 200
         data = response.data.decode()
@@ -181,20 +135,9 @@ class TestStats:
 
     def test_stats_shows_category_count(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('글1', '내용', 'tech')
-            )
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('글2', '내용', 'tech')
-            )
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('글3', '내용', 'life')
-            )
-            db.commit()
+            insert_post('글1', '내용', 'tech')
+            insert_post('글2', '내용', 'tech')
+            insert_post('글3', '내용', 'life')
         response = client.get('/stats')
         data = response.data.decode()
         assert 'tech' in data
@@ -231,12 +174,7 @@ class TestValidation:
 
     def test_edit_empty_title_returns_error(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('원본 글', '원본 내용', 'general')
-            )
-            db.commit()
+            insert_post('원본 글', '원본 내용', 'general')
         response = client.post('/edit/1', data={
             'title': '',
             'content': '수정 내용',
@@ -247,12 +185,7 @@ class TestValidation:
 
     def test_edit_empty_content_returns_error(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('원본 글', '원본 내용', 'general')
-            )
-            db.commit()
+            insert_post('원본 글', '원본 내용', 'general')
         response = client.post('/edit/1', data={
             'title': '수정 제목',
             'content': '',
@@ -292,23 +225,13 @@ class TestSearch:
 
     def test_search_finds_matching_title(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('Flask 튜토리얼', '내용입니다', 'tech')
-            )
-            db.commit()
+            insert_post('Flask 튜토리얼', '내용입니다', 'tech')
         response = client.get('/search?q=Flask')
         assert 'Flask 튜토리얼'.encode() in response.data
 
     def test_search_finds_matching_content(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('제목', 'Python 프로그래밍 가이드', 'tech')
-            )
-            db.commit()
+            insert_post('제목', 'Python 프로그래밍 가이드', 'tech')
         response = client.get('/search?q=Python')
         assert '제목'.encode() in response.data
 
@@ -327,16 +250,8 @@ class TestSearch:
 
     def test_search_model_function(self, client):
         with app.app_context():
-            db = get_db()
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('Flask 입문', 'Flask 웹 개발', 'tech')
-            )
-            db.execute(
-                "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                ('Django 입문', 'Django 웹 개발', 'tech')
-            )
-            db.commit()
+            insert_post('Flask 입문', 'Flask 웹 개발', 'tech')
+            insert_post('Django 입문', 'Django 웹 개발', 'tech')
             from models import search_posts
             results = search_posts('Flask')
             assert len(results) == 1
@@ -346,13 +261,8 @@ class TestSearch:
 class TestPagination:
     def _insert_posts(self, client, count):
         with app.app_context():
-            db = get_db()
             for i in range(count):
-                db.execute(
-                    "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                    (f'게시글제목{i+1}호', f'내용 {i+1}', 'general')
-                )
-            db.commit()
+                insert_post(f'게시글제목{i+1}호', f'내용 {i+1}', 'general')
 
     def test_index_limits_posts_per_page(self, client):
         self._insert_posts(client, 12)
@@ -391,18 +301,10 @@ class TestPagination:
 
     def test_pagination_with_category(self, client):
         with app.app_context():
-            db = get_db()
             for i in range(8):
-                db.execute(
-                    "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                    (f'기술글{i+1}호', f'내용 {i+1}', 'tech')
-                )
+                insert_post(f'기술글{i+1}호', f'내용 {i+1}', 'tech')
             for i in range(3):
-                db.execute(
-                    "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
-                    (f'일상글{i+1}호', f'내용 {i+1}', 'life')
-                )
-            db.commit()
+                insert_post(f'일상글{i+1}호', f'내용 {i+1}', 'life')
         response = client.get('/?category=tech&page=1')
         data = response.data.decode()
         assert '일상글' not in data


### PR DESCRIPTION
## Identified Code Smells

### 1. Duplicated Validation Logic (app.py:40-45, 54-59)
`create()`와 `edit()` 라우트에서 폼 데이터 추출 + 검증 로직이 동일하게 반복.
- **Why it's a smell:** DRY 원칙 위반. 검증 규칙 변경 시 두 곳을 수정해야 하므로 버그 발생 가능성 증가.

### 2. Duplicated SQL Query Construction (models.py:44-82)
`get_all_posts()`에서 category 필터링 + ORDER BY + LIMIT/OFFSET SQL 패턴이 4번 반복.
- **Why it's a smell:** Shotgun Surgery. WHERE 조건 변경 시 4곳 수정 필요.

### 3. Hardcoded URL Paths in Templates (index.html, search.html, post.html, base.html)
`"/post/{{ id }}"`, `"/search"`, `"/?category=tech"` 등 URL 문자열이 하드코딩.
- **Why it's a smell:** Magic String. 라우트 URL 변경 시 모든 템플릿을 수동 수정해야 함.

### 4. Duplicated Template Code (index.html, search.html)
게시글 목록 렌더링 HTML(`<ul class="post-list">...</ul>`)이 두 템플릿에 동일하게 존재.
- **Why it's a smell:** DRY 위반. 목록 디자인 변경 시 두 파일을 동시에 수정해야 함.

### 5. Duplicated Test Setup + Schema Duplication (test_app.py)
`db.execute("INSERT INTO posts...")` 패턴이 ~15회 반복. posts 스키마가 models.py와 test_app.py에 중복 정의.
- **Why it's a smell:** 테스트 유지보수 비용 증가. 스키마 변경 시 두 곳 수정 필요.

---

## AI Collaboration Log

### Refactoring Strategy 제안 (AI → Human)

**Strategy A: Extract Method + Template Partial** (선택됨)
- 헬퍼 함수 추출 (`validate_post_form()`, `_build_post_query()`, `insert_post()`)
- Jinja2 `{% include %}` 로 템플릿 부분 추출
- Flask `url_for()` 활용
- models.py의 `SCHEMA` 상수를 테스트에서 재사용

**Strategy B: Form Object + Query Builder (OOP)**
- PostForm 클래스, QueryBuilder 클래스 도입
- 과도한 추상화 → 프로젝트 규모에 비해 과도함

**Strategy C: Minimal Extract (함수 추출만)**
- 템플릿/URL 문제는 해결하지 않음 → 불완전

### Decision: Strategy A 선택
- Flask 표준 패턴(`url_for`, `include`)을 활용하여 자연스럽고
- 과도한 추상화 없이 5가지 스멜 모두 해결 가능

---

## Refactoring Commits

| Commit | Smell Addressed |
|--------|----------------|
| `refactor: extract validate_post_form()` | #1 Duplicated Validation |
| `refactor: extract _build_post_query()` | #2 Duplicated SQL |
| `refactor: replace hardcoded URLs with url_for()` | #3 Magic Strings |
| `refactor: extract _post_list.html partial` | #4 Duplicated Template |
| `refactor: extract insert_post() helper and reuse SCHEMA` | #5 Duplicated Test Setup |

## Improved Design
- `validate_post_form()`: 폼 검증 로직이 한 곳에 집중 → 유지보수 용이
- `_build_post_query()`: SQL WHERE 절 생성을 한 곳에서 관리 → Shotgun Surgery 제거
- `url_for()`: 라우트 변경에 자동 대응 → Magic String 제거
- `_post_list.html`: 게시글 목록 HTML 단일 소스 → 디자인 변경 시 한 곳만 수정
- `insert_post()` + `SCHEMA` 재사용: 테스트 코드 98줄 감소, 스키마 단일 소스

## Test Results
```
37 passed in 0.29s — 모든 기존 테스트 통과 (동작 변경 없음)
```