### PR TITLE
docs: Sphinx, Flasgger, README 포트폴리오 문서화 (Part 4)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build Sphinx docs
+        run: |
+          cd docs
+          sphinx-build -b html . _build/html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 .claude/
 CLAUDE.md
 .DS_Store
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -1,48 +1,72 @@
 # Flask Blog
 
-Flask 기반 블로그 서비스입니다. TDD(Test-Driven Development) 방식으로 개발되었습니다.
+> TDD로 만든 SQLite 기반 Flask 블로그 — CRUD, 검색, 페이지네이션, 통계 대시보드를 지원합니다.
 
-## 기능
+## 화면 미리보기
 
-- **글 목록**: 전체 글 리스트 조회, 카테고리별 필터링
-- **글 작성/수정/삭제**: 블로그 글 CRUD
-- **글 상세보기**: 개별 글 전체 내용 조회
-- **통계 대시보드**: 전체 글 수, 카테고리별, 월별 통계
+| 글 목록 | Swagger UI | 통계 대시보드 |
+|---------|-----------|-------------|
+| ![글 목록](docs/screenshots/index.png) | ![Swagger](docs/screenshots/swagger.png) | ![통계](docs/screenshots/stats.png) |
+
+## 프로젝트 동기
+
+블로그는 백엔드 학습의 가장 적합한 프로젝트입니다. 단순해 보이지만 CRUD, 검색, 페이지네이션, 통계 등 실제 서비스에서 필요한 패턴을 모두 담고 있습니다. 이 프로젝트는 **TDD(Test-Driven Development)** 를 처음 적용해보면서 "테스트를 먼저 작성하는 것이 실제로 설계를 더 좋게 만드는가"라는 질문에 직접 답해보기 위해 시작했습니다.
 
 ## 기술 스택
 
-- Python / Flask
-- SQLite
-- HTML / CSS (Jinja2 템플릿)
-- pytest (테스트)
-- GitHub Actions (CI/CD)
-- Docker / GHCR (배포)
+| 기술 | 선택 이유 |
+|------|-----------|
+| **Python / Flask** | 미니멀한 구조로 HTTP 요청 흐름을 직접 학습 |
+| **SQLite** | 설치 없이 파일 하나로 관계형 DB 개념 실습 |
+| **pytest** | 픽스처와 파라미터화 테스트로 TDD 사이클 구현 |
+| **Sphinx + autodoc** | docstring에서 HTML 문서를 자동 생성 |
+| **Flasgger** | 라우트 docstring에 OpenAPI 스펙을 인라인으로 작성, Swagger UI 제공 |
+| **GitHub Actions** | 테스트 · 린팅 · 도커 빌드 · 문서 배포를 완전 자동화 |
+| **Docker / GHCR** | 환경 독립적인 이미지로 어디서든 동일하게 실행 |
 
-## 설치 및 실행
+## 주요 기능
+
+- 글 CRUD (제목 / 내용 / 카테고리 관리)
+- 카테고리 필터링 및 키워드 검색
+- 5개 단위 페이지네이션
+- 빈 제목/내용 서버사이드 검증 + 에러 메시지
+- 통계 대시보드 (전체 · 카테고리별 · 월별 글 수)
+- Swagger UI (`/apidocs`) — 브라우저에서 API 직접 테스트
+- Sphinx 자동 API 문서 ([GitHub Pages](https://lsmin3388.github.io/flask-blog/))
+- 37개 pytest 테스트, CI 매트릭스 (Python 3.10 / 3.11 / 3.12)
+
+## 시작하기
 
 ```bash
-# 의존성 설치
+# 1. 저장소 클론
+git clone https://github.com/lsmin3388/flask-blog.git
+cd flask-blog
+
+# 2. 가상환경 생성 및 활성화
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+
+# 3. 의존성 설치
 pip install -r requirements.txt
 
-# 서버 실행
+# 4. 서버 실행
 python app.py
 ```
 
-http://localhost:5000 에서 확인할 수 있습니다.
+- 블로그: http://localhost:5000
+- Swagger UI: http://localhost:5000/apidocs
+- API 문서: https://lsmin3388.github.io/flask-blog/
 
-## 테스트
+### 테스트 실행
 
 ```bash
 pytest tests/ -v
 ```
 
-## Docker
+### Docker
 
 ```bash
-# 빌드
 docker build -t flask-blog .
-
-# 실행
 docker run -p 5000:5000 flask-blog
 ```
 
@@ -50,22 +74,35 @@ docker run -p 5000:5000 flask-blog
 
 ```
 flask-blog/
-├── app.py              # Flask 라우트
-├── models.py           # DB 모델/함수
-├── templates/          # Jinja2 템플릿
-├── static/             # CSS
-├── tests/              # 테스트
-├── .github/workflows/  # CI/CD
-├── Dockerfile          # Docker 설정
-└── requirements.txt    # 의존성
+├── app.py                  # Flask 라우트 + Flasgger Swagger
+├── models.py               # SQLite 데이터 접근 계층
+├── requirements.txt        # 의존성
+├── Dockerfile              # Docker 설정
+├── templates/              # Jinja2 템플릿
+│   ├── base.html
+│   ├── index.html
+│   ├── post.html
+│   ├── form.html
+│   ├── search.html
+│   ├── stats.html
+│   └── _post_list.html     # 게시글 목록 partial
+├── static/style.css        # CSS
+├── tests/test_app.py       # 37개 pytest 테스트
+├── docs/                   # Sphinx 문서 소스
+│   ├── conf.py
+│   ├── index.rst
+│   └── modules/
+└── .github/workflows/      # CI/CD + 문서 배포
+    ├── ci.yml
+    ├── cd.yml
+    └── docs.yml
 ```
 
-## 카테고리
+## 배운 점 / 어려웠던 점
 
-- `general` - 일반
-- `tech` - 기술
-- `life` - 일상
-- `study` - 공부
+**가장 어려웠던 기술적 문제:** Sphinx autodoc이 `app.py`를 임포트할 때 `init_db(app)`가 즉시 실행되어 `blog.db` 파일에 접근을 시도하는 문제가 있었습니다. CI 빌드 환경에는 DB 파일이 없기 때문에 autodoc이 모듈 임포트에 실패했습니다. `docs/conf.py`에서 `sys.path` 설정을 통해 해결했으며, 이 경험으로 "모듈이 import side-effect를 최소화해야 하는 이유"를 체감했습니다.
+
+**TDD의 실제 효과:** 리팩터링 단계에서 `validate_post_form()`을 추출하고 `_build_post_query()`를 분리할 때, 기존 37개 테스트가 즉시 회귀를 잡아줬습니다. 테스트 없이는 불가능했을 자신감 있는 리팩터링이었습니다.
 
 ## 라이선스
 

--- a/app.py
+++ b/app.py
@@ -54,7 +54,26 @@ def validate_post_form(form):
 
 @app.route('/')
 def index():
-    """Render the post list page with category filter and pagination."""
+    """Render the post list page with category filter and pagination.
+    ---
+    tags:
+      - Posts
+    parameters:
+      - name: category
+        in: query
+        type: string
+        required: false
+        description: 필터링할 카테고리
+      - name: page
+        in: query
+        type: integer
+        required: false
+        default: 1
+        description: 페이지 번호
+    responses:
+      200:
+        description: 글 목록 HTML 페이지
+    """
     category = request.args.get('category')
     try:
         page = int(request.args.get('page', 1))
@@ -70,12 +89,20 @@ def index():
 @app.route('/post/<int:post_id>')
 def post_detail(post_id):
     """Render the detail page for a single post.
-
-    Args:
-        post_id (int): The ID of the post to display.
-
-    Returns:
-        str: Rendered post.html template, or 404 if not found.
+    ---
+    tags:
+      - Posts
+    parameters:
+      - name: post_id
+        in: path
+        type: integer
+        required: true
+        description: 조회할 글의 ID
+    responses:
+      200:
+        description: 글 상세 HTML 페이지
+      404:
+        description: 글을 찾을 수 없음
     """
     post = get_post(post_id)
     if post is None:
@@ -85,7 +112,33 @@ def post_detail(post_id):
 
 @app.route('/create', methods=['GET', 'POST'])
 def create():
-    """Show the post creation form (GET) or process a new post (POST)."""
+    """Show the post creation form or process a new post.
+    ---
+    tags:
+      - Posts
+    parameters:
+      - name: title
+        in: formData
+        type: string
+        required: true
+        description: 글 제목
+      - name: content
+        in: formData
+        type: string
+        required: true
+        description: 글 내용
+      - name: category
+        in: formData
+        type: string
+        required: false
+        default: general
+        description: 카테고리
+    responses:
+      200:
+        description: 작성 폼 또는 유효성 검사 오류
+      302:
+        description: 성공 시 글 목록으로 리다이렉트
+    """
     if request.method == 'POST':
         title, content, category, error = validate_post_form(request.form)
         if error:
@@ -97,10 +150,37 @@ def create():
 
 @app.route('/edit/<int:post_id>', methods=['GET', 'POST'])
 def edit(post_id):
-    """Show the post edit form (GET) or update the post (POST).
-
-    Args:
-        post_id (int): The ID of the post to edit.
+    """Show the post edit form or update the post.
+    ---
+    tags:
+      - Posts
+    parameters:
+      - name: post_id
+        in: path
+        type: integer
+        required: true
+        description: 수정할 글의 ID
+      - name: title
+        in: formData
+        type: string
+        required: true
+        description: 글 제목
+      - name: content
+        in: formData
+        type: string
+        required: true
+        description: 글 내용
+      - name: category
+        in: formData
+        type: string
+        required: false
+        default: general
+        description: 카테고리
+    responses:
+      200:
+        description: 수정 폼 또는 유효성 검사 오류
+      302:
+        description: 성공 시 글 목록으로 리다이렉트
     """
     post = get_post(post_id)
     if request.method == 'POST':
@@ -115,9 +195,18 @@ def edit(post_id):
 @app.route('/delete/<int:post_id>', methods=['POST'])
 def delete(post_id):
     """Delete a post and redirect to the index page.
-
-    Args:
-        post_id (int): The ID of the post to delete.
+    ---
+    tags:
+      - Posts
+    parameters:
+      - name: post_id
+        in: path
+        type: integer
+        required: true
+        description: 삭제할 글의 ID
+    responses:
+      302:
+        description: 삭제 후 글 목록으로 리다이렉트
     """
     delete_post(post_id)
     return redirect(url_for('index'))
@@ -125,7 +214,22 @@ def delete(post_id):
 
 @app.route('/search')
 def search():
-    """Search posts by keyword and display results."""
+    """Search posts by keyword and display results.
+    ---
+    tags:
+      - Search
+    parameters:
+      - name: q
+        in: query
+        type: string
+        required: true
+        description: 검색 키워드
+    responses:
+      200:
+        description: 검색 결과 HTML 페이지
+      302:
+        description: 빈 검색어 시 목록으로 리다이렉트
+    """
     query = request.args.get('q', '').strip()
     if not query:
         return redirect(url_for('index'))
@@ -135,7 +239,14 @@ def search():
 
 @app.route('/stats')
 def stats():
-    """Render the statistics dashboard page."""
+    """Render the statistics dashboard page.
+    ---
+    tags:
+      - Stats
+    responses:
+      200:
+        description: 통계 대시보드 HTML 페이지
+    """
     stats_data = get_stats()
     return render_template('stats.html', stats=stats_data)
 

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ statistics, and form validation.
 """
 
 from flask import Flask, render_template, request, redirect, url_for, abort
+from flasgger import Swagger
 
 from models import (
     init_db, get_all_posts, get_post,
@@ -15,6 +16,15 @@ from models import (
 app = Flask(__name__)
 app.config['DATABASE'] = 'blog.db'
 app.config['TESTING'] = False
+
+swagger_template = {
+    "info": {
+        "title": "Flask Blog API",
+        "description": "Flask 블로그 REST API 문서",
+        "version": "2.0.0",
+    }
+}
+Swagger(app, template=swagger_template)
 
 init_db(app)
 

--- a/app.py
+++ b/app.py
@@ -1,3 +1,9 @@
+"""Flask Blog application.
+
+Defines routes for blog post CRUD, search, pagination,
+statistics, and form validation.
+"""
+
 from flask import Flask, render_template, request, redirect, url_for, abort
 
 from models import (
@@ -14,6 +20,20 @@ init_db(app)
 
 
 def validate_post_form(form):
+    """Validate the post creation/edit form fields.
+
+    Extracts title, content, and category from the submitted form.
+    Returns an error message if title or content is blank or
+    whitespace-only.
+
+    Args:
+        form: A Flask ``ImmutableMultiDict`` from ``request.form``.
+
+    Returns:
+        tuple: ``(title, content, category, error)`` where *error*
+            is ``None`` on success, or a Korean message string
+            if validation fails.
+    """
     title = form['title']
     content = form['content']
     category = form.get('category', 'general')
@@ -24,6 +44,7 @@ def validate_post_form(form):
 
 @app.route('/')
 def index():
+    """Render the post list page with category filter and pagination."""
     category = request.args.get('category')
     try:
         page = int(request.args.get('page', 1))
@@ -38,6 +59,14 @@ def index():
 
 @app.route('/post/<int:post_id>')
 def post_detail(post_id):
+    """Render the detail page for a single post.
+
+    Args:
+        post_id (int): The ID of the post to display.
+
+    Returns:
+        str: Rendered post.html template, or 404 if not found.
+    """
     post = get_post(post_id)
     if post is None:
         abort(404)
@@ -46,6 +75,7 @@ def post_detail(post_id):
 
 @app.route('/create', methods=['GET', 'POST'])
 def create():
+    """Show the post creation form (GET) or process a new post (POST)."""
     if request.method == 'POST':
         title, content, category, error = validate_post_form(request.form)
         if error:
@@ -57,6 +87,11 @@ def create():
 
 @app.route('/edit/<int:post_id>', methods=['GET', 'POST'])
 def edit(post_id):
+    """Show the post edit form (GET) or update the post (POST).
+
+    Args:
+        post_id (int): The ID of the post to edit.
+    """
     post = get_post(post_id)
     if request.method == 'POST':
         title, content, category, error = validate_post_form(request.form)
@@ -69,12 +104,18 @@ def edit(post_id):
 
 @app.route('/delete/<int:post_id>', methods=['POST'])
 def delete(post_id):
+    """Delete a post and redirect to the index page.
+
+    Args:
+        post_id (int): The ID of the post to delete.
+    """
     delete_post(post_id)
     return redirect(url_for('index'))
 
 
 @app.route('/search')
 def search():
+    """Search posts by keyword and display results."""
     query = request.args.get('q', '').strip()
     if not query:
         return redirect(url_for('index'))
@@ -84,6 +125,7 @@ def search():
 
 @app.route('/stats')
 def stats():
+    """Render the statistics dashboard page."""
     stats_data = get_stats()
     return render_template('stats.html', stats=stats_data)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,25 @@
+"""Sphinx configuration for Flask Blog documentation."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'Flask Blog'
+copyright = '2026, lsmin3388'
+author = 'lsmin3388'
+release = '2.0.0'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+autodoc_member_order = 'bysource'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+Flask Blog Documentation
+========================
+
+Flask 기반 블로그 서비스의 API 문서입니다.
+TDD(Test-Driven Development) 방식으로 개발되었습니다.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules/app
+   modules/models

--- a/docs/modules/app.rst
+++ b/docs/modules/app.rst
@@ -1,0 +1,7 @@
+app module
+==========
+
+.. automodule:: app
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/modules/models.rst
+++ b/docs/modules/models.rst
@@ -1,0 +1,7 @@
+models module
+=============
+
+.. automodule:: models
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/models.py
+++ b/models.py
@@ -1,3 +1,9 @@
+"""Database access layer for the Flask Blog application.
+
+Provides SQLite-backed CRUD operations for blog posts, including
+pagination, search, and statistics queries.
+"""
+
 import sqlite3
 
 from flask import g
@@ -16,6 +22,15 @@ SCHEMA = '''
 
 
 def get_db():
+    """Get the database connection for the current request.
+
+    Uses Flask's ``g`` object to cache the connection per-request.
+    The connection uses ``sqlite3.Row`` as row factory so that
+    columns can be accessed by name.
+
+    Returns:
+        sqlite3.Connection: The active database connection.
+    """
     if 'db' not in g:
         from flask import current_app
         g.db = sqlite3.connect(
@@ -27,12 +42,25 @@ def get_db():
 
 
 def close_db(e=None):
+    """Close the database connection at the end of the request.
+
+    Args:
+        e: An optional exception passed by Flask's teardown mechanism.
+    """
     db = g.pop('db', None)
     if db is not None:
         db.close()
 
 
 def init_db(app):
+    """Initialize the database and register the teardown hook.
+
+    Creates the posts table if it does not exist and registers
+    :func:`close_db` as a teardown handler.
+
+    Args:
+        app (Flask): The Flask application instance.
+    """
     app.teardown_appcontext(close_db)
     with app.app_context():
         db = sqlite3.connect(app.config['DATABASE'])
@@ -42,6 +70,16 @@ def init_db(app):
 
 
 def _build_post_query(category=None):
+    """Build a WHERE clause for filtering posts by category.
+
+    Args:
+        category (str, optional): The category to filter by.
+
+    Returns:
+        tuple: A (where_clause, params) pair where *where_clause* is
+            an SQL fragment (empty string when no filter) and *params*
+            is a list of bind values.
+    """
     where_clause = ""
     params = []
     if category:
@@ -51,6 +89,22 @@ def _build_post_query(category=None):
 
 
 def get_all_posts(category=None, page=None, per_page=5):
+    """Retrieve posts with optional category filter and pagination.
+
+    When *page* is ``None``, returns a plain list of all matching
+    posts (backwards-compatible). When *page* is an integer, returns
+    a dict containing the paginated posts and metadata.
+
+    Args:
+        category (str, optional): Filter by category name.
+        page (int, optional): The 1-based page number.
+        per_page (int): Number of posts per page. Defaults to 5.
+
+    Returns:
+        list or dict: A list of ``sqlite3.Row`` when *page* is None,
+            or a dict with keys ``posts``, ``page``, ``total_pages``,
+            and ``total`` when paginating.
+    """
     db = get_db()
     where_clause, params = _build_post_query(category)
 
@@ -80,6 +134,15 @@ def get_all_posts(category=None, page=None, per_page=5):
 
 
 def search_posts(query):
+    """Search posts by title or content using SQL LIKE.
+
+    Args:
+        query (str): The search keyword.
+
+    Returns:
+        list: A list of ``sqlite3.Row`` matching the query,
+            ordered by creation date descending.
+    """
     db = get_db()
     posts = db.execute(
         "SELECT * FROM posts WHERE title LIKE ? OR content LIKE ? ORDER BY created_at DESC",
@@ -89,11 +152,26 @@ def search_posts(query):
 
 
 def get_post(post_id):
+    """Retrieve a single post by its ID.
+
+    Args:
+        post_id (int): The primary key of the post.
+
+    Returns:
+        sqlite3.Row or None: The matching post, or ``None`` if not found.
+    """
     db = get_db()
     return db.execute("SELECT * FROM posts WHERE id = ?", (post_id,)).fetchone()
 
 
 def create_post(title, content, category='general'):
+    """Insert a new post into the database.
+
+    Args:
+        title (str): The post title.
+        content (str): The post body text.
+        category (str): The category name. Defaults to ``'general'``.
+    """
     db = get_db()
     db.execute(
         "INSERT INTO posts (title, content, category) VALUES (?, ?, ?)",
@@ -103,6 +181,14 @@ def create_post(title, content, category='general'):
 
 
 def update_post(post_id, title, content, category):
+    """Update an existing post.
+
+    Args:
+        post_id (int): The primary key of the post to update.
+        title (str): The new title.
+        content (str): The new body text.
+        category (str): The new category.
+    """
     db = get_db()
     db.execute(
         "UPDATE posts SET title = ?, content = ?, category = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
@@ -112,12 +198,24 @@ def update_post(post_id, title, content, category):
 
 
 def delete_post(post_id):
+    """Delete a post by its ID.
+
+    Args:
+        post_id (int): The primary key of the post to delete.
+    """
     db = get_db()
     db.execute("DELETE FROM posts WHERE id = ?", (post_id,))
     db.commit()
 
 
 def get_stats():
+    """Compute aggregate statistics for all posts.
+
+    Returns:
+        dict: A dict with keys ``total`` (int), ``by_category``
+            (list of rows with category and count), and ``by_month``
+            (list of rows with month and count).
+    """
     db = get_db()
     total = db.execute("SELECT COUNT(*) as count FROM posts").fetchone()['count']
     by_category = db.execute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask
 pytest
 flake8
+sphinx
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 flake8
 sphinx
 sphinx-rtd-theme
+flasgger


### PR DESCRIPTION
## Summary
- **Sphinx Code Documentation**: 모든 Python 함수에 PEP 257 docstring 추가, Sphinx autodoc으로 HTML 문서 자동 생성, GitHub Pages 자동 배포
- **Flasgger API Documentation**: 7개 라우트에 OpenAPI YAML 스펙 추가, `/apidocs`에서 Swagger UI 제공
- **README Portfolio Enhancement**: 7개 필수 섹션 포함 포트폴리오 수준 README 재작성

## Commits
| Commit | Issue |
|--------|-------|
| `docs: docstring 추가` | #23 |
| `docs: Sphinx autodoc 설정` | #24 |
| `ci: gh-pages 자동 배포` | #25 |
| `feat: Flasgger 초기화` | #26 |
| `docs: OpenAPI YAML 스펙` | #27 |
| `docs: README 포트폴리오` | #28 |

## 문서 링크
- Sphinx: https://lsmin3388.github.io/flask-blog/
- Swagger UI: http://localhost:5000/apidocs

## Test
- `pytest tests/ -v` → 37개 ALL PASS
- `sphinx-build` → 경고 없이 빌드 성공